### PR TITLE
Global Humbug reporting opt-out

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -12,11 +12,14 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
         run: pip install -U pip
       - name: Install dev dependencies

--- a/python/humbug/consent.py
+++ b/python/humbug/consent.py
@@ -12,10 +12,13 @@ class HumbugConsent:
     HumbugConsent stores the client's consent settings.
     """
 
+    BUGGER_OFF = "BUGGER_OFF"
+
     def __init__(self, *mechanisms: Union[bool, ConsentMechanism]) -> None:
         if not mechanisms:
             mechanisms = (False,)
         self._mechanisms = mechanisms
+        self._bugger_off_mechanism = environment_variable_opt_out(self.BUGGER_OFF, yes)
 
     def check(self) -> bool:
         """
@@ -25,11 +28,13 @@ class HumbugConsent:
         for mechanism in self._mechanisms:
             if mechanism is True:
                 continue
-            elif mechanism is False:
+            if mechanism is False:
                 return False
             elif not cast(ConsentMechanism, mechanism)():
                 return False
-        return True
+        # If the user has set BUGGER_OFF=yes then do not assume consent. Otherwise, at this point,
+        # we can assume consent.
+        return self._bugger_off_mechanism()
 
 
 def environment_variable_opt_in(

--- a/python/humbug/test_consent.py
+++ b/python/humbug/test_consent.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest import mock
 
 from . import consent
 
@@ -118,6 +119,16 @@ class TestHumbugConsent(unittest.TestCase):
             ),
         )
         self.assertFalse(consent_state.check())
+
+    @mock.patch.dict(os.environ, {consent.HumbugConsent.BUGGER_OFF: "true"})
+    def test_bugger_off(self):
+        consent_state = consent.HumbugConsent(True)
+        self.assertFalse(consent_state.check())
+
+    @mock.patch.dict(os.environ, {consent.HumbugConsent.BUGGER_OFF: "false"})
+    def test_bugger_on(self):
+        consent_state = consent.HumbugConsent(True)
+        self.assertTrue(consent_state.check())
 
 
 if __name__ == "__main__":

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as ifp:
 
 setup(
     name="humbug",
-    version="0.1.5",
+    version="0.1.6",
     packages=find_packages(),
     install_requires=["bugout"],
     extras_require={


### PR DESCRIPTION
If user has set `BUGGER_OFF=true`, do not report anything ever, for any package using Humbug.