### PR TITLE
Reporter has option to not create thread

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as ifp:
 
 setup(
     name="humbug",
-    version="0.1.8",
+    version="0.1.9",
     packages=find_packages(),
     install_requires=["bugout"],
     extras_require={


### PR DESCRIPTION
If a `humbug.report.Reporter` object is instantiated with
`mode=Modes.SYNCHRONOUS`, it does not create a thread for asynchronous
reporting. Instead, all publications are made synchronously by the
reporter, and it is the caller's responsibility to implement
asynchronous behaviour however they would like.