### PR TITLE
logging reporter

### DIFF
--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -76,6 +76,7 @@ class Reporter:
             )
 
         self.is_excepthook_set = False
+        self.is_loggerhook_set = False
 
     def wait(self) -> None:
         concurrent.futures.wait(
@@ -356,15 +357,18 @@ Release: `{os_release}`
         tags: Optional[List[str]] = None,
         publish: bool = True,
     ) -> None:
-        old_factory = logging.getLogRecordFactory()
+        if not self.is_loggerhook_set:
+            old_factory = logging.getLogRecordFactory()
 
-        def record_factory(*args, **kwargs):
-            record = old_factory(*args, **kwargs)
-            if record.levelno >= level:
-                self.logging_report(record=record, tags=tags, publish=publish)
-            return record
+            def record_factory(*args, **kwargs):
+                record = old_factory(*args, **kwargs)
+                if record.levelno >= level:
+                    self.logging_report(record=record, tags=tags, publish=publish)
+                return record
 
-        logging.setLogRecordFactory(record_factory)
+            logging.setLogRecordFactory(record_factory)
+
+            self.is_loggerhook_set = True
 
     def setup_excepthook(
         self, tags: Optional[List[str]] = None, publish: bool = True

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -6,6 +6,7 @@ import atexit
 import concurrent.futures
 from dataclasses import dataclass, field
 from enum import Enum
+from logging import LogRecord
 import os
 import pkg_resources
 import sys
@@ -284,6 +285,44 @@ Release: `{os_release}`
         report = Report(title, content, tags)
         if publish:
             self.publish(report, wait=wait)
+        return report
+
+    def logging_report(
+        self,
+        record: LogRecord,
+        tags: Optional[List[str]] = None,
+        publish: bool = True,
+        wait: bool = False,
+    ) -> Report:
+        title = "{} - Logging error - {}".format(self.name, record.module)
+        error_content = """### User timestamp
+```
+{user_time}
+```
+
+### Module name
+```
+{module_name}
+```
+
+### Error message
+```
+{error_message}
+```""".format(
+            user_time=int(time.time()),
+            module_name=record.module,
+            error_message=record.getMessage(),
+        )
+        if tags is None:
+            tags = []
+        tags.append("type:logging")
+        tags.extend(self.system_tags())
+
+        report = Report(title=title, content=error_content, tags=tags)
+
+        if publish:
+            self.publish(report, wait=wait)
+
         return report
 
     def compound_report(

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -352,7 +352,7 @@ Release: `{os_release}`
 
     def setup_loggerhook(
         self,
-        levels: list,
+        level: int,
         tags: Optional[List[str]] = None,
         publish: bool = True,
     ) -> None:
@@ -360,7 +360,7 @@ Release: `{os_release}`
 
         def record_factory(*args, **kwargs):
             record = old_factory(*args, **kwargs)
-            if record.levelno in levels:
+            if record.levelno >= level:
                 self.logging_report(record=record, tags=tags, publish=publish)
             return record
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as ifp:
 
 setup(
     name="humbug",
-    version="0.1.15",
+    version="0.1.16",
     packages=find_packages(),
     install_requires=["bugout"],
     extras_require={


### PR DESCRIPTION
Works with logging factory
```python
    log_level = logging.ERROR
    logging.basicConfig(
        level=log_level,
        format="%(asctime)s: %(name)s:%(levelname)s %(message)s"
    )
    old_factory = logging.getLogRecordFactory()

    def record_factory(*args, **kwargs):
        record = old_factory(*args, **kwargs)
        bugout_reporter.logging_report(record=record, publish=True
        )
        return record

    logging.setLogRecordFactory(record_factory)
```