### PR TITLE
Add @wraps decorator to Reporter wrappers

### DIFF
--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -6,6 +6,7 @@ import atexit
 import concurrent.futures
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import wraps
 
 import logging
 import os
@@ -433,6 +434,7 @@ Feature: {name}
         self,
         callable: Callable,
     ) -> Callable:
+        @wraps(callable)
         def wrapped_callable(*args, **kwargs):
             parameters = {**kwargs}
             for i, arg in enumerate(args):
@@ -448,6 +450,7 @@ Feature: {name}
         self,
         callable: Callable,
     ) -> Callable:
+        @wraps(callable)
         def wrapped_callable(*args, **kwargs):
             result = None
             try:


### PR DESCRIPTION
I was experiencing an issue where documentation was not being correctly generated for functions which use the `@reporter.record_call` decorator. [See this pdoc thread](https://github.com/pdoc3/pdoc/issues/98).

The solution is to use `@functools.wraps` around the `wrapped_callable` definition so that the function's identity (name, content, etc) are preserved. [See the docs for functools.wraps](https://docs.python.org/3/library/functools.html#functools.wraps)