### PR TITLE
Two fixes to the humbug.bash script

### DIFF
--- a/scripts/humbug.bash
+++ b/scripts/humbug.bash
@@ -64,8 +64,8 @@ echo "Processing in batches of size BUGOUT_SEARCH_LIMIT=$BUGOUT_SEARCH_LIMIT"
 OFFSET=0
 while [ "$OFFSET" -lt "$TOTAL_RESULTS" ]
 do
-    OUTPUT_FILE="$BUGOUT_OUTPUT_DIRECTORY/$OFFSET.json"
+    OUTPUT_FILE="$BUGOUT_OUTPUT_DIRECTORY/$(printf "%07d" $OFFSET).json"
     echo "Processing $BUGOUT_SEARCH_LIMIT items with offset $OFFSET into $OUTPUT_FILE"
-    bugout entries search "$SEARCH_QUERY" --limit "$BUGOUT_SEARCH_LIMIT" --offset "$OFFSET" > "$OUTPUT_FILE"
+    bugout entries search "$SEARCH_QUERY" --params order=asc --limit "$BUGOUT_SEARCH_LIMIT" --offset "$OFFSET" > "$OUTPUT_FILE"
     OFFSET=$((OFFSET + BUGOUT_SEARCH_LIMIT))
 done


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

1. Order the query results, to ensure that pagination works.
2. Left-pad the filenames with zeros, so that their lexicographic
   sort order (as returned by ls) is also their pagination order.

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->

I ran `BUGOUT_ACCESS_TOKEN=XXX BUGOUT_JOURNAL_ID=YYY ./scripts/humbug.bash` and observed the filenames being written, and that the content contained consistently ordered data.

<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
