### PR TITLE
Support of blacklisted keys for feature reports

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -126,25 +126,49 @@ set `MY_APP_NO_CONSENT=1`, then again no reports will get sent back.
 On the other hand, if the user has set `MY_APP_CONSENT=true` and left `MY_APP_NO_CONSENT` unset or
 set to a value other than `1`, Humbug will send you any reports you have configured.
 
-### Blacklist
+### Blacklisting parameters in feature reports
 
-There is a possibility to provide custom functions or use predefined at `blacklist.filter_parameters_by_key` for blacklist functionality.
+Arguments to functions and other callables can sometimes contain sensitive information which you may
+not want to include in Humbug reports.
 
-Just add a list of keys you want to remove from the `feature_report` result and specify the function:
+Blacklist functions allow you to specify which parameters from an argument list to filter out of your
+feature reports.
+
+#### `blacklist.generate_filter_parameters_by_key_fn`
+
+If you would just like to filter out all paramters with a given name, you can use the `blacklist.generate_filter_parameters_by_key_fn`.
+
+For example, to ignore all parameters named `token` (case insensitive), you would instantiate your
+`HumbugReporter` as follows:
 
 ```python
-reporter = Reporter(
-    ...
-    blacklist_keys=["private"],
-    blacklist_fn=blacklist.filter_parameters_by_key,
+reporter = HumbugReporter(
+    ...,
+    blacklist_fn=blacklist.generate_filter_parameters_by_key_fn(["token"]),
 )
 ```
 
-### Example: activeloopai/Hub
+#### Custom blacklist functions
 
-[This pull request](https://github.com/activeloopai/Hub/pull/624) shows how
+You could also implement a custom blacklist function to remove all parameters that contained the substring
+`token` (case insensitive):
+
+```python
+def blacklist_token_parameters_fn(params: Dict[str, Any]) -> Dict[str, Any]:
+    admissible_params = {k:v for k, v in params.items() if "token" not in k}
+    return admissible_params
+
+reporter = HumbugReporter(
+    ...,
+    blacklist_fn=blacklist_token_parameters_fn
+)
+```
+
+### Case study: activeloopai/deeplake
+
+[This pull request](https://github.com/activeloopai/deeplake/pull/624) shows how
 [Activeloop](https://www.activeloop.ai/) integrated Humbug into their popular
-[`Hub`](https://github.com/activeloopai/Hub) tool.
+[`deeplake`](https://github.com/activeloopai/deeplake) tool.
 
 This example shows how to use Humbug to record consent in a configuration file that the user
 can modify at will. It also shows how to add custom tags to your Humbug reports.

--- a/python/README.md
+++ b/python/README.md
@@ -126,6 +126,20 @@ set `MY_APP_NO_CONSENT=1`, then again no reports will get sent back.
 On the other hand, if the user has set `MY_APP_CONSENT=true` and left `MY_APP_NO_CONSENT` unset or
 set to a value other than `1`, Humbug will send you any reports you have configured.
 
+### Blacklist
+
+There is a possibility to provide custom functions or use predefined at `blacklist.filter_parameters_by_key` for blacklist functionality.
+
+Just add a list of keys you want to remove from the `feature_report` result and specify the function:
+
+```python
+reporter = Reporter(
+    ...
+    blacklist_keys=["private"],
+    blacklist_fn=blacklist.filter_parameters_by_key,
+)
+```
+
 ### Example: activeloopai/Hub
 
 [This pull request](https://github.com/activeloopai/Hub/pull/624) shows how

--- a/python/humbug/blacklist.py
+++ b/python/humbug/blacklist.py
@@ -1,44 +1,57 @@
 """
 Various implementations of the blacklist functionality.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 
-def filter_parameters_by_key(
+def generate_filter_parameters_by_key_fn(
     blacklist_keys: List[str],
-    parameters: Dict[str, Any],
-) -> Dict[str, Any]:
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     """
-    Applies blacklist filter to provided parameters and to 2nd layer of
-    inner dictionary parameter if exists.
+    Generates a parameter filter function which filters out the parameters whose names are in the given
+    list of blacklist_keys.
+
+    The comparison to blacklist_keys is case insensitive.
     """
-    whitelisted_parameters: Dict[str, Any] = {}
 
-    for key in parameters.keys():
-        if key.lower() in blacklist_keys:
-            continue
+    lowercase_blacklist_keys = [key.lower() for key in blacklist_keys]
 
-        key_as_dict: Optional[Dict[str, Any]] = None
-        for d in dir(parameters[key]):
-            if d == "keys":
-                key_as_dict = parameters[key]
-                break
-            elif d == "dict":  # Pydantic models support
-                key_as_dict = parameters[key].dict()
-                break
+    def filter_parameters_by_key(
+        parameters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Applies blacklist filter to provided parameters and to 2nd layer of
+        inner dictionary parameter if exists.
+        """
+        whitelisted_parameters: Dict[str, Any] = {}
 
-        if key_as_dict is not None:
-            try:
-                inner_dict: Dict[str, str] = {}
-                for inner_key in key_as_dict.keys():
-                    if inner_key.lower() in blacklist_keys:
-                        continue
-                    inner_dict[inner_key] = str(key_as_dict[inner_key])
-                whitelisted_parameters[key] = inner_dict
+        for key in parameters.keys():
+            if key.lower() in lowercase_blacklist_keys:
                 continue
-            except Exception:
-                pass
 
-        whitelisted_parameters[key] = str(parameters[key])
+            key_as_dict: Optional[Dict[str, Any]] = None
+            for d in dir(parameters[key]):
+                if d == "keys":
+                    key_as_dict = parameters[key]
+                    break
+                elif d == "dict":  # Pydantic models support
+                    key_as_dict = parameters[key].dict()
+                    break
 
-    return whitelisted_parameters
+            if key_as_dict is not None:
+                try:
+                    inner_dict: Dict[str, str] = {}
+                    for inner_key in key_as_dict.keys():
+                        if inner_key.lower() in lowercase_blacklist_keys:
+                            continue
+                        inner_dict[inner_key] = str(key_as_dict[inner_key])
+                    whitelisted_parameters[key] = inner_dict
+                    continue
+                except Exception:
+                    pass
+
+            whitelisted_parameters[key] = str(parameters[key])
+
+        return whitelisted_parameters
+
+    return filter_parameters_by_key

--- a/python/humbug/blacklist.py
+++ b/python/humbug/blacklist.py
@@ -1,0 +1,44 @@
+"""
+Various implementations of the blacklist functionality.
+"""
+from typing import Any, Dict, List, Optional
+
+
+def filter_parameters_by_key(
+    blacklist_keys: List[str],
+    parameters: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Applies blacklist filter to provided parameters and to 2nd layer of
+    inner dictionary parameter if exists.
+    """
+    whitelisted_parameters: Dict[str, Any] = {}
+
+    for key in parameters.keys():
+        if key.lower() in blacklist_keys:
+            continue
+
+        key_as_dict: Optional[Dict[str, Any]] = None
+        for d in dir(parameters[key]):
+            if d == "keys":
+                key_as_dict = parameters[key]
+                break
+            elif d == "dict":  # Pydantic models support
+                key_as_dict = parameters[key].dict()
+                break
+
+        if key_as_dict is not None:
+            try:
+                inner_dict: Dict[str, str] = {}
+                for inner_key in key_as_dict.keys():
+                    if inner_key.lower() in blacklist_keys:
+                        continue
+                    inner_dict[inner_key] = str(key_as_dict[inner_key])
+                whitelisted_parameters[key] = inner_dict
+                continue
+            except Exception:
+                pass
+
+        whitelisted_parameters[key] = str(parameters[key])
+
+    return whitelisted_parameters

--- a/python/humbug/blacklist.py
+++ b/python/humbug/blacklist.py
@@ -19,6 +19,30 @@ def generate_filter_parameters_by_key_fn(
     def filter_parameters_by_key(
         parameters: Dict[str, Any],
     ) -> Dict[str, Any]:
+        return {
+            k: str(v)
+            for k, v in parameters.items()
+            if k.lower() not in lowercase_blacklist_keys
+        }
+
+    return filter_parameters_by_key
+
+
+def generate_filter_parameters_by_key_inner_fn(
+    blacklist_keys: List[str],
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Generates a parameter filter function which filters out the parameters whose names are in the given
+    list of blacklist_keys for 1st and 2nd layer of dictionary. Expands pydantic model to dictionary.
+
+    The comparison to blacklist_keys is case insensitive.
+    """
+
+    lowercase_blacklist_keys = [key.lower() for key in blacklist_keys]
+
+    def filter_parameters_by_key_inner(
+        parameters: Dict[str, Any],
+    ) -> Dict[str, Any]:
         """
         Applies blacklist filter to provided parameters and to 2nd layer of
         inner dictionary parameter if exists.
@@ -54,4 +78,4 @@ def generate_filter_parameters_by_key_fn(
 
         return whitelisted_parameters
 
-    return filter_parameters_by_key
+    return filter_parameters_by_key_inner

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -60,6 +60,7 @@ class HumbugReporter:
         mode: Modes = Modes.DEFAULT,
         url: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        blacklisted_keys: Optional[List[str]] = None,
     ):
         if url is None:
             url = DEFAULT_URL
@@ -93,6 +94,10 @@ class HumbugReporter:
         if tags is not None:
             self.tags = tags
 
+        self.blacklisted_keys: List[str] = []
+        if blacklisted_keys is not None:
+            self.blacklisted_keys = blacklisted_keys
+
     def wait(self) -> None:
         concurrent.futures.wait(
             self.report_futures, timeout=float(self.timeout_seconds)
@@ -118,6 +123,44 @@ class HumbugReporter:
             tags.append("client:{}".format(self.client_id))
 
         return tags
+
+    def _apply_blacklist_to_parameters(
+        self, parameters: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Applies blacklist filter to provided parameters and to 2nd layer of
+        inner dictionary parameter if exists.
+        """
+        whitelisted_parameters: Dict[str, Any] = {}
+
+        for key in parameters.keys():
+            if key in self.blacklisted_keys:
+                continue
+
+            key_as_dict: Optional[Dict[str, Any]] = None
+            for d in dir(parameters[key]):
+                if d == "keys":
+                    key_as_dict = parameters[key]
+                    break
+                elif d == "dict":  # Pydantic models support
+                    key_as_dict = parameters[key].dict()
+                    break
+
+            if key_as_dict is not None:
+                try:
+                    inner_dict: Dict[str, str] = {}
+                    for inner_key in key_as_dict.keys():
+                        if inner_key in self.blacklisted_keys:
+                            continue
+                        inner_dict[inner_key] = str(key_as_dict[inner_key])
+                    whitelisted_parameters[key] = inner_dict
+                    continue
+                except Exception:
+                    pass
+
+            whitelisted_parameters[key] = str(parameters[key])
+
+        return whitelisted_parameters
 
     def _post_body(self, report: Report) -> Dict[str, Any]:
         return {
@@ -382,12 +425,16 @@ Release: `{os_release}`
     def feature_report(
         self,
         feature_name: str,
-        parameters: Dict[str, str],
+        parameters: Dict[str, Any],
         tags: Optional[List[str]] = None,
         publish: bool = True,
         wait: bool = False,
+        blacklist_apply: bool = True,
     ) -> Report:
         title = "Feature used: {name}".format(name=feature_name)
+
+        if blacklist_apply:
+            parameters = self._apply_blacklist_to_parameters(parameters)
 
         parameters_content = "\n".join(
             [
@@ -438,7 +485,7 @@ Feature: {name}
         def wrapped_callable(*args, **kwargs):
             parameters = {**kwargs}
             for i, arg in enumerate(args):
-                parameters["arg.{}".format(i)] = str(arg)
+                parameters["arg.{}".format(i)] = arg
 
             self.feature_report(callable.__name__, parameters)
 

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -60,10 +60,7 @@ class HumbugReporter:
         mode: Modes = Modes.DEFAULT,
         url: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        blacklist_keys: List[str] = [],
-        blacklist_fn: Optional[
-            Callable[[List[str], Dict[str, Any]], Dict[str, Any]]
-        ] = None,
+        blacklist_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
     ):
         if url is None:
             url = DEFAULT_URL
@@ -97,7 +94,6 @@ class HumbugReporter:
         if tags is not None:
             self.tags = tags
 
-        self.blacklist_keys = blacklist_keys
         self.blacklist_fn = blacklist_fn
 
     def wait(self) -> None:
@@ -398,7 +394,7 @@ Release: `{os_release}`
         title = "Feature used: {name}".format(name=feature_name)
 
         if apply_blacklist and self.blacklist_fn is not None:
-            parameters = self.blacklist_fn(self.blacklist_keys, parameters)
+            parameters = self.blacklist_fn(parameters)
 
         parameters_content = "\n".join(
             [

--- a/python/humbug/test_blacklist.py
+++ b/python/humbug/test_blacklist.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+import unittest
+
+from . import blacklist
+
+
+class TestGenerateFilterParametersByKeyFunction(unittest.TestCase):
+    """
+    Tests for blacklist.generate_filter_parameters_by_key_fn.
+    """
+
+    def test_exact_matches(self):
+        params: Dict[str, Any] = {"good": 1, "bad": "lol"}
+        blacklist_fn = blacklist.generate_filter_parameters_by_key_fn(["bad"])
+        filtered_params = blacklist_fn(params)
+        self.assertDictEqual(filtered_params, {"good": "1"})
+
+    def test_case_insensitive_matches(self):
+        params: Dict[str, Any] = {"good": 1, "BAD": "lol"}
+        blacklist_fn = blacklist.generate_filter_parameters_by_key_fn(["Bad"])
+        filtered_params = blacklist_fn(params)
+        self.assertDictEqual(filtered_params, {"good": "1"})

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -11,8 +11,7 @@ class TestReporter(unittest.TestCase):
             name="TestReporter",
             consent=self.consent,
             tags=["humbug-unit-test"],
-            blacklist_keys=["private"],
-            blacklist_fn=blacklist.filter_parameters_by_key,
+            blacklist_fn=blacklist.generate_filter_parameters_by_key_fn(["private"]),
         )
         self.reporter.publish = MagicMock()
 

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -11,7 +11,9 @@ class TestReporter(unittest.TestCase):
             name="TestReporter",
             consent=self.consent,
             tags=["humbug-unit-test"],
-            blacklist_fn=blacklist.generate_filter_parameters_by_key_fn(["private"]),
+            blacklist_fn=blacklist.generate_filter_parameters_by_key_inner_fn(
+                ["private"]
+            ),
         )
         self.reporter.publish = MagicMock()
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as ifp:
 
 setup(
     name="humbug",
-    version="0.2.7",
+    version="0.2.8",
     packages=find_packages(),
     package_data={"humbug": ["py.typed"]},
     install_requires=[


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

During reporter creation specify list of `blacklisted_keys` like:
```python
humbug_reporter = HumbugReporter(
    ...
    blacklisted_keys=["token", "created_at"]
)
```

After it all `@humbug_reporter.record_call` automatically remove blacklisted keys from arguments. 

Also, if blacklisted keys required in report, it could be set manually to ignore blacklist with `humbug_reporter.feature_report(..., blacklist_apply=False)`

## How to test these changes?

Added test cases and tested locally with API.

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
