### PR TITLE
Made a change to how blacklist_fn works

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -126,25 +126,49 @@ set `MY_APP_NO_CONSENT=1`, then again no reports will get sent back.
 On the other hand, if the user has set `MY_APP_CONSENT=true` and left `MY_APP_NO_CONSENT` unset or
 set to a value other than `1`, Humbug will send you any reports you have configured.
 
-### Blacklist
+### Blacklisting parameters in feature reports
 
-There is a possibility to provide custom functions or use predefined at `blacklist.filter_parameters_by_key` for blacklist functionality.
+Arguments to functions and other callables can sometimes contain sensitive information which you may
+not want to include in Humbug reports.
 
-Just add a list of keys you want to remove from the `feature_report` result and specify the function:
+Blacklist functions allow you to specify which parameters from an argument list to filter out of your
+feature reports.
+
+#### `blacklist.generate_filter_parameters_by_key_fn`
+
+If you would just like to filter out all paramters with a given name, you can use the `blacklist.generate_filter_parameters_by_key_fn`.
+
+For example, to ignore all parameters named `token` (case insensitive), you would instantiate your
+`HumbugReporter` as follows:
 
 ```python
-reporter = Reporter(
-    ...
-    blacklist_keys=["private"],
-    blacklist_fn=blacklist.filter_parameters_by_key,
+reporter = HumbugReporter(
+    ...,
+    blacklist_fn=blacklist.generate_filter_parameters_by_key_fn(["token"]),
 )
 ```
 
-### Example: activeloopai/Hub
+#### Custom blacklist functions
 
-[This pull request](https://github.com/activeloopai/Hub/pull/624) shows how
+You could also implement a custom blacklist function to remove all parameters that contained the substring
+`token` (case insensitive):
+
+```python
+def blacklist_token_parameters_fn(params: Dict[str, Any]) -> Dict[str, Any]:
+    admissible_params = {k:v for k, v in params.items() if "token" not in k}
+    return admissible_params
+
+reporter = HumbugReporter(
+    ...,
+    blacklist_fn=blacklist_token_parameters_fn
+)
+```
+
+### Case study: activeloopai/deeplake
+
+[This pull request](https://github.com/activeloopai/deeplake/pull/624) shows how
 [Activeloop](https://www.activeloop.ai/) integrated Humbug into their popular
-[`Hub`](https://github.com/activeloopai/Hub) tool.
+[`deeplake`](https://github.com/activeloopai/deeplake) tool.
 
 This example shows how to use Humbug to record consent in a configuration file that the user
 can modify at will. It also shows how to add custom tags to your Humbug reports.

--- a/python/humbug/blacklist.py
+++ b/python/humbug/blacklist.py
@@ -1,44 +1,57 @@
 """
 Various implementations of the blacklist functionality.
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 
-def filter_parameters_by_key(
+def generate_filter_parameters_by_key_fn(
     blacklist_keys: List[str],
-    parameters: Dict[str, Any],
-) -> Dict[str, Any]:
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     """
-    Applies blacklist filter to provided parameters and to 2nd layer of
-    inner dictionary parameter if exists.
+    Generates a parameter filter function which filters out the parameters whose names are in the given
+    list of blacklist_keys.
+
+    The comparison to blacklist_keys is case insensitive.
     """
-    whitelisted_parameters: Dict[str, Any] = {}
 
-    for key in parameters.keys():
-        if key.lower() in blacklist_keys:
-            continue
+    lowercase_blacklist_keys = [key.lower() for key in blacklist_keys]
 
-        key_as_dict: Optional[Dict[str, Any]] = None
-        for d in dir(parameters[key]):
-            if d == "keys":
-                key_as_dict = parameters[key]
-                break
-            elif d == "dict":  # Pydantic models support
-                key_as_dict = parameters[key].dict()
-                break
+    def filter_parameters_by_key(
+        parameters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Applies blacklist filter to provided parameters and to 2nd layer of
+        inner dictionary parameter if exists.
+        """
+        whitelisted_parameters: Dict[str, Any] = {}
 
-        if key_as_dict is not None:
-            try:
-                inner_dict: Dict[str, str] = {}
-                for inner_key in key_as_dict.keys():
-                    if inner_key.lower() in blacklist_keys:
-                        continue
-                    inner_dict[inner_key] = str(key_as_dict[inner_key])
-                whitelisted_parameters[key] = inner_dict
+        for key in parameters.keys():
+            if key.lower() in lowercase_blacklist_keys:
                 continue
-            except Exception:
-                pass
 
-        whitelisted_parameters[key] = str(parameters[key])
+            key_as_dict: Optional[Dict[str, Any]] = None
+            for d in dir(parameters[key]):
+                if d == "keys":
+                    key_as_dict = parameters[key]
+                    break
+                elif d == "dict":  # Pydantic models support
+                    key_as_dict = parameters[key].dict()
+                    break
 
-    return whitelisted_parameters
+            if key_as_dict is not None:
+                try:
+                    inner_dict: Dict[str, str] = {}
+                    for inner_key in key_as_dict.keys():
+                        if inner_key.lower() in lowercase_blacklist_keys:
+                            continue
+                        inner_dict[inner_key] = str(key_as_dict[inner_key])
+                    whitelisted_parameters[key] = inner_dict
+                    continue
+                except Exception:
+                    pass
+
+            whitelisted_parameters[key] = str(parameters[key])
+
+        return whitelisted_parameters
+
+    return filter_parameters_by_key

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -60,9 +60,7 @@ class HumbugReporter:
         mode: Modes = Modes.DEFAULT,
         url: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        blacklist_fn: Optional[
-            Callable[[List[str], Dict[str, Any]], Dict[str, Any]]
-        ] = None,
+        blacklist_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
     ):
         if url is None:
             url = DEFAULT_URL

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -60,7 +60,6 @@ class HumbugReporter:
         mode: Modes = Modes.DEFAULT,
         url: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        blacklist_keys: List[str] = [],
         blacklist_fn: Optional[
             Callable[[List[str], Dict[str, Any]], Dict[str, Any]]
         ] = None,
@@ -97,7 +96,6 @@ class HumbugReporter:
         if tags is not None:
             self.tags = tags
 
-        self.blacklist_keys = blacklist_keys
         self.blacklist_fn = blacklist_fn
 
     def wait(self) -> None:
@@ -398,7 +396,7 @@ Release: `{os_release}`
         title = "Feature used: {name}".format(name=feature_name)
 
         if apply_blacklist and self.blacklist_fn is not None:
-            parameters = self.blacklist_fn(self.blacklist_keys, parameters)
+            parameters = self.blacklist_fn(parameters)
 
         parameters_content = "\n".join(
             [

--- a/python/humbug/test_blacklist.py
+++ b/python/humbug/test_blacklist.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+import unittest
+
+from . import blacklist
+
+
+class TestGenerateFilterParametersByKeyFunction(unittest.TestCase):
+    """
+    Tests for blacklist.generate_filter_parameters_by_key_fn.
+    """
+
+    def test_exact_matches(self):
+        params: Dict[str, Any] = {"good": 1, "bad": "lol"}
+        blacklist_fn = blacklist.generate_filter_parameters_by_key_fn(["bad"])
+        filtered_params = blacklist_fn(params)
+        self.assertDictEqual(filtered_params, {"good": "1"})
+
+    def test_case_insensitive_matches(self):
+        params: Dict[str, Any] = {"good": 1, "BAD": "lol"}
+        blacklist_fn = blacklist.generate_filter_parameters_by_key_fn(["Bad"])
+        filtered_params = blacklist_fn(params)
+        self.assertDictEqual(filtered_params, {"good": "1"})

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -11,8 +11,7 @@ class TestReporter(unittest.TestCase):
             name="TestReporter",
             consent=self.consent,
             tags=["humbug-unit-test"],
-            blacklist_keys=["private"],
-            blacklist_fn=blacklist.filter_parameters_by_key,
+            blacklist_fn=blacklist.generate_filter_parameters_by_key_fn(["private"]),
         )
         self.reporter.publish = MagicMock()
 


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Removed blacklist_keys from reporter `__init__` function.

@kompotkot : I think we could make the `filter_parameters_by_key` function a lot simpler, but maybe I just don't understand the use cases you are supporting there.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Added `humbug/test_blacklist.py` with tests for just the blacklist functionality.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
