### PR TITLE
Fix missing setuptools

### DIFF
--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -11,7 +11,6 @@ import json
 
 import logging
 import os
-import pkg_resources
 import sys
 import time
 import traceback
@@ -39,6 +38,13 @@ GPUtil = None
 
 try:
     import GPUtil  # type: ignore
+except ImportError:
+    pass
+
+pkg_resources = None
+
+try:
+    import pkg_resources  # type: ignore
 except ImportError:
     pass
 
@@ -115,6 +121,7 @@ class HumbugReporter:
 
         self.psutil_exists = psutil is not None
         self.gputil_exists = GPUtil is not None
+        self.pkg_resources_exists = pkg_resources is not None
 
     def wait(self) -> None:
         concurrent.futures.wait(
@@ -332,9 +339,12 @@ Release: `{os_release}`
             tags = []
         tags.append("type:dependencies")
 
-        available_packages = [
-            str(package_info) for package_info in pkg_resources.working_set
-        ]
+        available_packages = []
+
+        if self.pkg_resources_exists:
+            available_packages = [
+                str(package_info) for package_info in pkg_resources.working_set  # type: ignore
+            ]
         content = "```\n{}\n```".format("\n".join(available_packages))
         report = Report(title, content, tags)
         if publish:

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -345,6 +345,8 @@ Release: `{os_release}`
             available_packages = [
                 str(package_info) for package_info in pkg_resources.working_set  # type: ignore
             ]
+        else:
+            tags.append("warning:pkg_resources_import_failed")
         content = "```\n{}\n```".format("\n".join(available_packages))
         report = Report(title, content, tags)
         if publish:

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -347,6 +347,9 @@ Release: `{os_release}`
             ]
         else:
             tags.append("warning:pkg_resources_import_failed")
+            available_packages.append(
+                "Failed to import pkg_resources. Package versions are not available."
+            )
         content = "```\n{}\n```".format("\n".join(available_packages))
         report = Report(title, content, tags)
         if publish:

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -57,7 +57,13 @@ class TestReporter(unittest.TestCase):
     def test_packages_report_successful(self):
         tags = ["a", "b", "c"]
         pkg_report = self.reporter.packages_report(tags=tags, publish=False)
-        self.assertSetEqual(set(pkg_report.tags), set(tags + ["type:dependencies"]))
+
+        excepted_tags = tags + ["type:packages"]
+
+        if not self.reporter.pkg_resources_exists:
+            excepted_tags.append("warning:pkg_resources_import_failed")
+
+        self.assertSetEqual(set(pkg_report.tags), set(tags + excepted_tags))
 
     def test_post_body(self):
         report_title = "xylophone"

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -143,7 +143,7 @@ class TestReporter(unittest.TestCase):
         report = publish_args[0][0]
         self.assertTrue("site:broken" in report.tags)
 
-    def test_metric_report(self):
+    def test_metrics_report(self):
         tags = ["a", "b", "c"]
         metrics_report = self.reporter.metrics_report(tags=tags, publish=False)
         self.assertSetEqual(set(metrics_report.tags), set(tags + ["type:metrics"]))

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -143,6 +143,11 @@ class TestReporter(unittest.TestCase):
         report = publish_args[0][0]
         self.assertTrue("site:broken" in report.tags)
 
+    def test_metric_report(self):
+        tags = ["a", "b", "c"]
+        metrics_report = self.reporter.metrics_report(tags=tags, publish=False)
+        self.assertSetEqual(set(metrics_report.tags), set(tags + ["type:metrics"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/humbug/test_report.py
+++ b/python/humbug/test_report.py
@@ -58,7 +58,7 @@ class TestReporter(unittest.TestCase):
         tags = ["a", "b", "c"]
         pkg_report = self.reporter.packages_report(tags=tags, publish=False)
 
-        excepted_tags = tags + ["type:packages"]
+        excepted_tags = tags + ["type:dependencies"]
 
         if not self.reporter.pkg_resources_exists:
             excepted_tags.append("warning:pkg_resources_import_failed")

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as ifp:
 
 setup(
     name="humbug",
-    version="0.3.0",
+    version="0.3.1",
     packages=find_packages(),
     package_data={"humbug": ["py.typed"]},
     install_requires=["requests", "dataclasses; python_version=='3.6'"],


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

manually
```
pip3 uninstall pkg_resources setuptools
python -m unittest discover -v
```
![image](https://user-images.githubusercontent.com/12608778/229779160-37727e9b-592b-4b75-a321-81465fc44a36.png)


<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
