### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.12, 3.11]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/python/humbug/report.py
+++ b/python/humbug/report.py
@@ -272,7 +272,7 @@ Release: `{os_release}`
             error_summary=repr(error),
             error_traceback="".join(
                 traceback.format_exception(
-                    etype=type(error),
+                    type(error),
                     value=error,
                     tb=error.__traceback__,
                 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as ifp:
 
 setup(
     name="humbug",
-    version="0.3.1",
+    version="0.3.2",
     packages=find_packages(),
     package_data={"humbug": ["py.typed"]},
     install_requires=["requests", "dataclasses; python_version=='3.6'"],


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Updated the call to `traceback.format_exception` to reflect it's signature change in Python 3.10: https://docs.python.org/3/library/traceback.html#traceback.format_exception

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Run tests

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
